### PR TITLE
chore(readme): show regular and inplace mode

### DIFF
--- a/backend/team-proj-abbr/README.md
+++ b/backend/team-proj-abbr/README.md
@@ -55,28 +55,38 @@ stack ghci --ghci-options -isrc --ghci-options -itest team-proj-abbr:team-proj-a
 
 2. `Replace`: - expansion of the full file content
 
-    ```bash
-    # create demo file:
-    $ echo "@@hl @@hl people" >> data/demo_file.txt
-    # demo with input and output:
-    $ stack exec shorthndr --  \
-        replace                         \
-        --input="data/demo_file.txt"    \
-        -o="./demo_file_o.txt"          \
-        -k="data/kb_example.csv"
-    $ cat ./demo_file_o.txt
-    hello hello people
-    # demo with inplace:
-    $ stack exec shorthndr --  \
-        replace                         \
-        --inplace                       \
-        --input="data/demo_file.txt"    \
-        -k="data/kb_example.csv"
-    $ cat data/demo_file.txt
-    hello hello people
-    # remove the demo files:
-    $ rm data/demo_file.txt ./demo_file_o.txt
-    ```
+    - _Basic_ approach, with `--input` and `--output`: 
+
+      ```bash
+      # create demo file:
+      $ echo "@@hl @@hl people" >> data/demo_file.txt
+      # demo with input and output
+      $ stack exec shorthndr --  \
+          replace                         \
+          --input="data/demo_file.txt"    \
+          -o="./demo_file_o.txt"          \
+          -k="data/kb_example.csv"
+      $ cat ./demo_file_o.txt
+      hello hello people
+      # remove the demo files:
+      $ rm data/demo_file.txt ./demo_file_o.txt
+      ```
+
+    - _Inplace_ approach, with `--input` and `--inplace`: 
+
+      ```bash
+      # create demo file:
+      $ echo "@@hl @@hl people" >> data/demo_file.txt
+      # demo with inplace
+      $ stack exec shorthndr --  \
+          replace                         \
+          --inplace                       \
+          --input="data/demo_file.txt"    \
+          -k="data/kb_example.csv"
+      $ cat ./data/demo_file.txt
+      hello hello people
+      $ rm data/demo_file.txt
+      ```
 
 3. `List`: - get all the knowledge base contents
 


### PR DESCRIPTION
# What

Separate entries for "regular" and "inplace" `replace` command in the readme. See #27 discussions for more details.