### PR TITLE
pier/chore-ga-tags

### DIFF
--- a/.github/workflows/backend-build-stable.yaml
+++ b/.github/workflows/backend-build-stable.yaml
@@ -89,6 +89,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DRAFT_RELEASE: "true"
         PRE_RELEASE: "false"
-        CHANGELOG_FILE: "CHANGELOG.md"
+        CHANGELOG_FILE: "ChangeLog.md"
         ALLOW_EMPTY_CHANGELOG: "false"
         ALLOW_TAG_PREFIX: "true"


### PR DESCRIPTION
# What
a tag causes a release to be built only if the tag starts with "v" now

# Why
to not accidentally push a release when we are not supposed to